### PR TITLE
wip - dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/*
+.github/*
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:10.15.1-jessie-slim
+RUN apt-get update && apt-get install -y git python gcc g++ make
+WORKDIR /srv/eos21
+COPY . .
+RUN npm i
+CMD ['/usr/local/bin/node','eos21.js']


### PR DESCRIPTION
** does not run yet **
known issues:
- there is a `./blackhole_address` file [referenced in eos21.js](https://github.com/makesense/eos21/blob/863b6672c5c3b7e59a3243e61c49877260ac861e/eos21.js#L30), but it is not mentioned in the README.  What should this file include?
